### PR TITLE
fix: fix enconding of whatsapps urls on share

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2,20 +2,26 @@ PODS:
   - creme_sharing (0.0.1):
     - Flutter
   - Flutter (1.0.0)
+  - path_provider_ios (0.0.1):
+    - Flutter
 
 DEPENDENCIES:
   - creme_sharing (from `.symlinks/plugins/creme_sharing/ios`)
   - Flutter (from `Flutter`)
+  - path_provider_ios (from `.symlinks/plugins/path_provider_ios/ios`)
 
 EXTERNAL SOURCES:
   creme_sharing:
     :path: ".symlinks/plugins/creme_sharing/ios"
   Flutter:
     :path: Flutter
+  path_provider_ios:
+    :path: ".symlinks/plugins/path_provider_ios/ios"
 
 SPEC CHECKSUMS:
   creme_sharing: cba214da4a82fb6d0b5fcd64d5fa6e651dd51c65
-  Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
+  Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
+  path_provider_ios: 14f3d2fd28c4fdb42f44e0f751d12861c43cee02
 
 PODFILE CHECKSUM: aafe91acc616949ddb318b77800a7f51bffa2a4c
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -42,7 +42,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.12"
+    version: "0.0.13"
   cupertino_icons:
     dependency: "direct main"
     description:

--- a/ios/Classes/SwiftCremeSharingPlugin.swift
+++ b/ios/Classes/SwiftCremeSharingPlugin.swift
@@ -63,7 +63,7 @@ public class SwiftCremeSharingPlugin: NSObject, FlutterPlugin {
       components.queryItems = [URLQueryItem(name: "message", value: message)]
       if let url = components.url, UIApplication.shared.canOpenURL(url) {
         if #available(iOS 10.0, *) {
-          UIApplication.shared.openURL(url)
+          UIApplication.shared.open(url)
           return result(nil)
         }
       } else {
@@ -72,16 +72,10 @@ public class SwiftCremeSharingPlugin: NSObject, FlutterPlugin {
     case "shareTextToWhatsapp":
       let arguments = (call.arguments as! [String: Any])
       let message = arguments["message"] as? String
-      let whatsMessage = "whatsapp://send?text=\(message!)"
-      var characterSet = CharacterSet.urlQueryAllowed
-      characterSet.insert(charactersIn: "?&")
-      let whatsAppURL = NSURL(
-        string: whatsMessage.addingPercentEncoding(withAllowedCharacters: characterSet)!)
-      if UIApplication.shared.canOpenURL(whatsAppURL! as URL) {
-        if #available(iOS 10.0, *) {
-          UIApplication.shared.openURL(whatsAppURL! as URL)
-          return result(nil)
-        }
+      var components = URLComponents(string: "whatsapp://send")!
+      components.queryItems = [URLQueryItem(name: "text", value: message)]
+      if let url = components.url, UIApplication.shared.canOpenURL(url) {
+        UIApplication.shared.open(url)
         return result(nil)
       } else {
         return result(nil)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: creme_sharing
 description: Flutter plugin to run all creme sharing routines.
-version: 0.0.12
+version: 0.0.13
 homepage:
 
 environment:


### PR DESCRIPTION
Fixing the same problem of https://stackoverflow.com/questions/63446111/whatsapp-share-not-working-properly-while-is-contain-in-link